### PR TITLE
fix: Improve and refactor entrypoint to make `--workers` and `--threads` argument working

### DIFF
--- a/src/app_server/__init__.py
+++ b/src/app_server/__init__.py
@@ -1,21 +1,30 @@
-import sys, os, re, subprocess, yaml, argparse, time, mimetypes, logging
+import argparse
+import logging
+import mimetypes
+import os
+import re
+import subprocess
+import sys
+import time
 import typing as t
-from werkzeug.wrappers import Request, Response
-from werkzeug.middleware.shared_data import SharedDataMiddleware
-from werkzeug.middleware.http_proxy import ProxyMiddleware
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
-from werkzeug.serving import run_simple, WSGIRequestHandler,_ansi_style,_log_add_style
-from werkzeug.wsgi import get_path_info, wrap_file
-from werkzeug.utils import get_content_type
+
+import yaml
+from werkzeug._internal import _logger  # noqa
 from werkzeug.http import http_date, is_resource_modified
-from werkzeug._internal import _logger
-from werkzeug.urls import uri_to_iri, url_unquote
-
-
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.middleware.http_proxy import ProxyMiddleware
+from werkzeug.middleware.shared_data import SharedDataMiddleware
+from werkzeug.serving import run_simple, WSGIRequestHandler, _ansi_style, \
+    _log_add_style
+from werkzeug.urls import uri_to_iri
+from werkzeug.utils import get_content_type
+from werkzeug.wrappers import Request, Response
+from werkzeug.wsgi import get_path_info, wrap_file
 
 __version__ = "0.9.9"
 
 subprocesses = []
+
 
 class myWSGIRequestHandler(WSGIRequestHandler):
     def log_date_time_string(self):
@@ -23,10 +32,11 @@ class myWSGIRequestHandler(WSGIRequestHandler):
         now = time.time()
         year, month, day, hh, mm, ss, x, y, z = time.localtime(now)
         s = "%04d-%02d-%02d %02d:%02d:%02d" % (
-            year , month,day , hh, mm, ss)
+            year, month, day, hh, mm, ss)
         return s
 
-    def log_request(self, code: t.Union[int, str] = "-", size: t.Union[int, str] = "-") -> None:
+    def log_request(self, code: t.Union[int, str] = "-",
+                    size: t.Union[int, str] = "-") -> None:
 
         """coloring the status code"""
         try:
@@ -39,7 +49,7 @@ class myWSGIRequestHandler(WSGIRequestHandler):
         code = str(code)
 
         log_type = "info"
-        if code != "200": #possibility to filter 200 requests
+        if code != "200":  # possibility to filter 200 requests
             log_type = "warning"
 
         if _log_add_style:
@@ -68,7 +78,8 @@ class myWSGIRequestHandler(WSGIRequestHandler):
             _logger.setLevel(logging.INFO)
             _logger.addHandler(logging.StreamHandler())
 
-        getattr(_logger, type)(f"[{self.log_date_time_string()}] {message % args}")
+        getattr(_logger, type)(
+            f"[{self.log_date_time_string()}] {message % args}")
 
 
 class WrappingApp(object):
@@ -79,11 +90,13 @@ class WrappingApp(object):
 
     def wsgi_app(self, environ, start_response):
         request = Request(environ)
-        response = Response(f'Path not found or invalid: {request.path}', status=404)
+        response = Response(f'Path not found or invalid: {request.path}',
+                            status=404)
         return response(environ, start_response)
 
     def __call__(self, environ, start_response):
         return self.wsgi_app(environ, start_response)
+
 
 class myProxy(ProxyMiddleware):
     """this addition allows to redirect all routes to given targets"""
@@ -102,7 +115,8 @@ class myProxy(ProxyMiddleware):
             f"{k}": _set_defaults(v) for k, v in targets.items()
         }
 
-    def __call__(self, environ: "WSGIEnvironment", start_response: "StartResponse") -> t.Iterable[bytes]:
+    def __call__(self, environ: "WSGIEnvironment",
+                 start_response: "StartResponse") -> t.Iterable[bytes]:
         path = get_path_info(environ, charset='utf-8', errors='replace')
         app = self.app
         for prefix, opts in self.targets.items():
@@ -111,6 +125,7 @@ class myProxy(ProxyMiddleware):
                 break
 
         return app(environ, start_response)
+
 
 class myDispatcher(DispatcherMiddleware):
     """use regex to find a matching route"""
@@ -129,16 +144,17 @@ class mySharedData(SharedDataMiddleware):
     """use regex to find a matching files"""
 
     def __init__(
-            self,
-            app,
-            exports,
-            disallow: None = None,
-            cache: bool = True,
-            cache_timeout: int = 60 * 60 * 12,
-            fallback_mimetype: str = "application/octet-stream",
+        self,
+        app,
+        exports,
+        disallow: None = None,
+        cache: bool = True,
+        cache_timeout: int = 60 * 60 * 12,
+        fallback_mimetype: str = "application/octet-stream",
     ) -> None:
         self.org_exports = exports.copy()
-        super().__init__(app, exports, disallow, cache, cache_timeout, fallback_mimetype)
+        super().__init__(app, exports, disallow, cache, cache_timeout,
+                         fallback_mimetype)
 
     def __call__(self, environ, start_response):
         path = get_path_info(environ)
@@ -147,8 +163,10 @@ class mySharedData(SharedDataMiddleware):
         for search_path, loader in self.exports:
             # lets check for regex, and inject real_path
             if re.match(search_path, path):
-                real_path = re.sub(search_path, self.org_exports[search_path], path, 1)
-                real_filename, file_loader = self.get_file_loader(real_path)(None)
+                real_path = re.sub(search_path, self.org_exports[search_path],
+                                   path, 1)
+                real_filename, file_loader = self.get_file_loader(real_path)(
+                    None)
 
                 if file_loader is not None:
                     break
@@ -168,11 +186,13 @@ class mySharedData(SharedDataMiddleware):
                 if file_loader is not None:
                     break
 
-        if file_loader is None or not self.is_allowed(real_filename):  # type: ignore
+        if file_loader is None or not self.is_allowed(
+            real_filename):  # type: ignore
             return self.app(environ, start_response)
 
         guessed_type = mimetypes.guess_type(real_filename)  # type: ignore
-        mime_type = get_content_type(guessed_type[0] or self.fallback_mimetype, "utf-8")
+        mime_type = get_content_type(guessed_type[0] or self.fallback_mimetype,
+                                     "utf-8")
 
         try:
             f, mtime, file_size = file_loader()
@@ -183,7 +203,8 @@ class mySharedData(SharedDataMiddleware):
 
         if self.cache:
             timeout = self.cache_timeout
-            etag = self.generate_etag(mtime, file_size, real_filename)  # type: ignore
+            etag = self.generate_etag(mtime, file_size,
+                                      real_filename)  # type: ignore
             headers += [
                 ("Etag", f'"{etag}"'),
                 ("Cache-Control", f"max-age={timeout}, public"),
@@ -209,7 +230,8 @@ class mySharedData(SharedDataMiddleware):
         return wrap_file(environ, f)
 
 
-def start_server(host, port, gunicorn_port, appFolder, appYaml, timeout, protocol="http"):
+def start_server(host, port, gunicorn_port, appFolder, appYaml, timeout,
+                 protocol="http"):
     """use the dispatcherMiddleware to connect SharedDataMiddleware and ProxyMiddleware with the wrapping app."""
     app = WrappingApp({})
     apps = {}
@@ -226,17 +248,19 @@ def start_server(host, port, gunicorn_port, appFolder, appYaml, timeout, protoco
             continue  # skip
 
         # print(pattern, route["url"], path)
-        apps[pattern] = mySharedData(app.wsgi_app, {route["url"]: os.path.join(appFolder, path)})
+        apps[pattern] = mySharedData(app.wsgi_app, {
+            route["url"]: os.path.join(appFolder, path)})
 
     apps.update({"/": myProxy(app.wsgi_app, {
         "/": {
             "target": f"{protocol}://{host}:{gunicorn_port}/",
             "host": None
         }
-    },timeout=timeout)})
+    }, timeout=timeout)})
     app.wsgi_app = myDispatcher(app.wsgi_app, apps)
 
-    run_simple(host, port, app, use_debugger=False, use_reloader=True, threaded=True, request_handler=myWSGIRequestHandler)
+    run_simple(host, port, app, use_debugger=False, use_reloader=True,
+               threaded=True, request_handler=myWSGIRequestHandler)
 
 
 def envVars(application_id: str, args: argparse.Namespace, app_yaml: dict):
@@ -245,7 +269,8 @@ def envVars(application_id: str, args: argparse.Namespace, app_yaml: dict):
     # from the CLI can overwrite it.
     if env_vars := app_yaml.get("env_variables"):
         if not isinstance(env_vars, dict):
-            raise TypeError(f"env_variables section in app.yaml must be a dict. Got {type(env_vars)}")
+            raise TypeError(
+                f"env_variables section in app.yaml must be a dict. Got {type(env_vars)}")
         os.environ |= {k: str(v) for k, v in app_yaml["env_variables"].items()}
 
     os.environ["GAE_ENV"] = "localdev"
@@ -255,7 +280,8 @@ def envVars(application_id: str, args: argparse.Namespace, app_yaml: dict):
     os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "0"
 
     if args.storage:
-        os.environ["STORAGE_EMULATOR_HOST"] = f"http://{args.host}:{args.storage_port}"
+        os.environ[
+            "STORAGE_EMULATOR_HOST"] = f"http://{args.host}:{args.storage_port}"
 
     if args.tasks:
         os.environ["TASKS_EMULATOR"] = f"{args.host}:{args.tasks_port}"
@@ -263,6 +289,7 @@ def envVars(application_id: str, args: argparse.Namespace, app_yaml: dict):
     # Merge environment variables from CLI parameter
     if args.env_var:
         os.environ |= dict(v.split("=", 1) for v in args.env_var)
+
 
 def patch_gunicorn():
     import gunicorn.workers.base
@@ -279,18 +306,26 @@ def patch_gunicorn():
         ))
 
 
-def start_gunicorn(args, appYaml, appFolder, myFolder):
+def start_gunicorn(
+    args: argparse.Namespace,
+    app_yaml: dict,
+    app_folder: str,
+) -> None:
     # Gunicorn call command
-    entrypoint = appYaml.get("entrypoint", "gunicorn -b :$PORT -w $WORKER --threads $THREADS "
-                                           "--disable-redirect-access-to-syslog main:app")
-    for var, value in {
-        "PORT": args.gunicorn_port,
-        "WORKER": args.worker,
-        "THREADS": args.threads
-    }.items():
-        entrypoint = entrypoint.replace(f"${var}", str(value))
+    if not (entrypoint := args.entrypoint):
+        entrypoint = app_yaml.get(
+            "entrypoint",
+            "gunicorn -b :$PORT --disable-redirect-access-to-syslog main:app"
+        )
+    entrypoint = entrypoint.replace(f"$PORT", str(args.gunicorn_port))
+    # Remove -w / --workers / --threads arguments,
+    # we set them later with the values from our argparser
+    entrypoint = re.sub(r"\s+-(w|-workers|-threads)\s+\d+", " ", entrypoint)
 
     entrypoint = entrypoint.split()
+    entrypoint.extend(["--workers", str(args.workers)])
+    entrypoint.extend(["--threads", str(args.threads)])
+
     if "--reload" not in entrypoint:
         entrypoint.insert(1, "--reload")
     if "--reuse-port" not in entrypoint:
@@ -298,9 +333,8 @@ def start_gunicorn(args, appYaml, appFolder, myFolder):
 
     entrypoint.extend(["--timeout", str(args.timeout)])
 
-    os.chdir(appFolder)
-    subprocesses.append(subprocess.Popen(entrypoint))
-    os.chdir(myFolder)
+    subprocesses.append(subprocess.Popen(entrypoint, cwd=app_folder))
+
 
 def main():
     """main entrypoint
@@ -314,24 +348,43 @@ def main():
         description="alternative dev_appserver"
     )
 
-    ap.add_argument("config_paths", metavar='yaml_path', nargs='+', help='Path to app.yaml file')
+    ap.add_argument("config_paths", metavar='yaml_path', nargs='+',
+                    help='Path to app.yaml file')
     ap.add_argument(
-        '-A', '--application', action='store', dest='app_id', required=True, help='Set the application id')
-    ap.add_argument('--host', default="localhost", help='host name to which application modules should bind')
-    ap.add_argument('--port', type=int, default=8080, help='port to which we bind the application')
-    ap.add_argument('--gunicorn_port', type=int, default=8090, help='internal gunicorn port')
-    ap.add_argument('--worker', type=int, default=1, help='amount of gunicorn workers')
-    ap.add_argument('--threads', type=int, default=5, help='amount of gunicorn threads')
-    ap.add_argument('--timeout', type=int, default=60, help='Time is seconds before gunicorn abort a request')
-    ap.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__)
+        '-A', '--application', action='store', dest='app_id', required=True,
+        help='Set the application id')
+    ap.add_argument('--host', default="localhost",
+                    help='host name to which application modules should bind')
+    ap.add_argument('--entrypoint', type=str, default=None,
+                    help='The entrypoint is the basic gunicorn command. By default, it\'s taken from app.yaml. '
+                         'This parameter can be used to set a different entrypoint. '
+                         'To provide this parameter via ViUR-CLI, you have to double quote it: '
+                         ' --entrypoint "\'gunicorn -b :\$PORT --disable-redirect-access-to-syslog main:app\'"')
+    ap.add_argument('--port', type=int, default=8080,
+                    help='port to which we bind the application')
+    ap.add_argument('--gunicorn_port', type=int, default=8090,
+                    help='internal gunicorn port')
+    ap.add_argument('--workers', '--worker', type=int, default=1,
+                    help='amount of gunicorn workers')
+    ap.add_argument('--threads', type=int, default=5,
+                    help='amount of gunicorn threads')
+    ap.add_argument('--timeout', type=int, default=60,
+                    help='Time is seconds before gunicorn abort a request')
+    ap.add_argument('-V', '--version', action='version',
+                    version='%(prog)s ' + __version__)
 
-    ap.add_argument('--storage', default=False, action="store_true", dest="storage", help="also start Storage Emulator")
-    ap.add_argument('--storage_port', type=int, default=8092, help='internal Storage Emulator Port')
+    ap.add_argument('--storage', default=False, action="store_true",
+                    dest="storage", help="also start Storage Emulator")
+    ap.add_argument('--storage_port', type=int, default=8092,
+                    help='internal Storage Emulator Port')
 
-    ap.add_argument('--tasks', default=False, action='store_true', dest="tasks", help='also start Task-Queue Emulator')
-    ap.add_argument('--tasks_port', type=int, default=8091, help='internal Task-Queue Emulator Port')
+    ap.add_argument('--tasks', default=False, action='store_true', dest="tasks",
+                    help='also start Task-Queue Emulator')
+    ap.add_argument('--tasks_port', type=int, default=8091,
+                    help='internal Task-Queue Emulator Port')
 
-    ap.add_argument('--cron', default=False, action='store_true', dest="cron", help='also start Cron Emulator')
+    ap.add_argument('--cron', default=False, action='store_true', dest="cron",
+                    help='also start Cron Emulator')
 
     ap.add_argument(
         '--env_var', metavar="KEY=VALUE", nargs="*",
@@ -350,7 +403,6 @@ def main():
 
     envVars(args.app_id, args, appYaml)
     patch_gunicorn()
-    myFolder = os.getcwd()
 
     # Check for correct runtime
     myRuntime = f"python{sys.version_info.major}{sys.version_info.minor}"
@@ -358,14 +410,13 @@ def main():
     assert appRuntime == myRuntime, f"app.yaml specifies {appRuntime} but you're on {myRuntime}, please correct this."
 
     if "WERKZEUG_RUN_MAIN" in os.environ and os.environ["WERKZEUG_RUN_MAIN"]:
-        #only start subprocesses wenn reloader starts
+        # only start subprocesses wenn reloader starts
 
         if args.storage:
-            storage_subprocess =subprocess.Popen(
+            storage_subprocess = subprocess.Popen(
                 f"gcloud-storage-emulator start --port={args.storage_port} --default-bucket={args.app_id}.appspot.com".split())
 
             subprocesses.append(storage_subprocess)
-
 
         if args.tasks and os.path.exists(os.path.join(appFolder, 'queue.yaml')):
             cron = ""
@@ -377,7 +428,7 @@ def main():
 
             subprocesses.append(tasks_subprocess)
 
-        start_gunicorn(args, appYaml, appFolder, myFolder)
+        start_gunicorn(args, appYaml, appFolder)
 
     start_server(args.host, args.port, args.gunicorn_port, appFolder, appYaml, args.timeout)
 
@@ -390,4 +441,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
* The app_server took the entrypoint from _app.yaml_, which has mostly set this property. So the default value of `appYaml.get("entrypoint")` was actually never used. But the entrypoint in _app.yaml_ cannot have a `$WORKER` or `$THREADS` variable -- they don't exist in gcloud (https://cloud.google.com/appengine/docs/standard/python3/runtime#environment_variables) So the variables were never replaced, because they don't exist. That made the `--worker` and `--thread` argument of the app_server useless.
* Now we remove these argument always from the provides entrypoint and re-add it with the values from our argparse. This get the argumnts working.
* Furthermore I added the option `--entrypoint` to provide an custom entrypoint, if the entrypoint is set in the _app.yaml_, but should be different for the local server. Setting this through the subproccess-call in the _viur-cli_ is a little bit tricky, but with double quoting it works.
* I (and PyCharm ^^) refactored this code a bit and add some type hints.