### PR TITLE
feat: Retrieve path from `REQUEST_URI`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install pypa/build
         run: >-

--- a/src/app_server/proxy.py
+++ b/src/app_server/proxy.py
@@ -1,9 +1,7 @@
 import typing as t
+import urllib
 from wsgiref.types import StartResponse, WSGIApplication, WSGIEnvironment
-
 from werkzeug.middleware.http_proxy import ProxyMiddleware
-from werkzeug.wsgi import get_path_info
-
 
 class Proxy(ProxyMiddleware):
     """this addition allows to redirect all routes to given targets"""
@@ -34,8 +32,8 @@ class Proxy(ProxyMiddleware):
 
         # Overide Pathinfo because werkzueg not unquote the path correct
         # https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L179-L208
-
-        path = environ["PATH_INFO"] = environ["REQUEST_URI"]
+        path =  environ["REQUEST_URI"]
+        path = urllib.parse.urlparse(path).path
         app = self.app
         for prefix, opts in self.targets.items():
             if path.startswith(prefix):

--- a/src/app_server/proxy.py
+++ b/src/app_server/proxy.py
@@ -31,7 +31,11 @@ class Proxy(ProxyMiddleware):
     def __call__(
         self, environ: WSGIEnvironment, start_response: StartResponse
     ) -> t.Iterable[bytes]:
-        path = get_path_info(environ)
+
+        # Overide Pathinfo because werkzueg not unquote the path correct
+        # https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L179-L208
+
+        path = environ["PATH_INFO"] = environ["REQUEST_URI"]
         app = self.app
         for prefix, opts in self.targets.items():
             if path.startswith(prefix):


### PR DESCRIPTION
In some cases, the path is not set correctly. 
For example, if you have a ‘%80’ in the url, werkzeuge tries to translate it. However, this leads to the url being assembled incorrectly.
https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L179-L208