### PR TITLE
feat: Add --forward option to proxy requests to external servers

### DIFF
--- a/src/app_server/__init__.py
+++ b/src/app_server/__init__.py
@@ -12,6 +12,7 @@ from werkzeug.serving import run_simple
 from . import utils
 from .app_wrapper import AppWrapper
 from .dispatcher import Dispatcher
+from .forward_proxy import ForwardProxy
 from .proxy import Proxy
 from .request_handler import CustomWSGIRequestHandler
 from .shared_data import SharedData
@@ -29,6 +30,7 @@ def start_server(
     app_yaml: dict,
     timeout: int,
     protocol: str = "http",
+    forward_rules: list[tuple[str, str]] | None = None,
 ) -> None:
     """use the dispatcherMiddleware to connect SharedDataMiddleware and ProxyMiddleware with the wrapping app."""
     app = AppWrapper()
@@ -48,6 +50,10 @@ def start_server(
         apps[pattern] = SharedData(
             app.wsgi_app, {route["url"]: os.path.join(app_folder, path)}
         )
+
+    # Register forward proxy rules (before the gunicorn proxy)
+    for pattern, target_url in forward_rules or []:
+        apps[pattern] = ForwardProxy(app.wsgi_app, target_url)
 
     apps["/"] = Proxy(
         app.wsgi_app,
@@ -181,6 +187,13 @@ def main():
              "environment variables. You can also define them in app.yaml."
     )
 
+    argument_parser.add_argument(
+        '--forward', metavar="PATTERN=URL", action="append", default=[],
+        help="Forward requests matching PATTERN (regex) to an external URL. "
+             "Can be specified multiple times. "
+             "Example: --forward '/file/.*=https://my-app.appspot.com'"
+    )
+
     args = argument_parser.parse_args()
 
     app_folder = Path(args.distribution_folder)
@@ -196,12 +209,20 @@ def main():
     app_runtime = app_yaml["runtime"]
     assert app_runtime == current_runtime, f"app.yaml specifies {app_runtime} but you're on {current_runtime}, please correct this."
 
+    # Parse --forward rules
+    forward_rules = []
+    for rule in args.forward:
+        if "=" not in rule:
+            argument_parser.error(f"Invalid --forward format: {rule!r} (expected PATTERN=URL)")
+        pattern, url = rule.split("=", 1)
+        forward_rules.append((pattern, url))
+
     if os.environ.get("WERKZEUG_RUN_MAIN"):
         # only start subprocesses wenn reloader starts
         start_gunicorn(args, app_yaml, app_folder)
 
     start_server(args.host, args.port, args.gunicorn_port, app_folder, app_yaml,
-                 args.timeout)
+                 args.timeout, forward_rules=forward_rules)
 
     try:
         for process in subprocesses:

--- a/src/app_server/forward_proxy.py
+++ b/src/app_server/forward_proxy.py
@@ -1,0 +1,51 @@
+import logging
+import urllib.request
+import urllib.error
+from wsgiref.types import StartResponse, WSGIApplication, WSGIEnvironment
+
+from werkzeug.wrappers import Request
+
+logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = 64 * 1024  # 64 KB
+
+
+class ForwardProxy:
+    """WSGI middleware that forwards matching requests to an external server.
+
+    Used to proxy requests (e.g. file downloads) to a production server
+    during local development, where those resources don't exist locally.
+
+    Responses are streamed chunk-wise so large files don't consume memory.
+    """
+
+    def __init__(self, app: WSGIApplication, target_url: str) -> None:
+        self.app = app
+        self.target_url = target_url.rstrip("/")
+
+    def __call__(
+        self, environ: WSGIEnvironment, start_response: StartResponse
+    ):
+        request = Request(environ)
+        target = self.target_url + request.path
+        if request.query_string:
+            target += "?" + request.query_string.decode()
+
+        try:
+            req = urllib.request.Request(target, method=request.method)
+            resp = urllib.request.urlopen(req, timeout=30)
+            headers = [(k, v) for k, v in resp.headers.items()]
+            start_response(f"{resp.status} {resp.reason}", headers)
+            return self._iter_response(resp)
+        except Exception as exc:
+            logger.debug("ForwardProxy failed for %s: %s", target, exc)
+            return self.app(environ, start_response)
+
+    @staticmethod
+    def _iter_response(resp):
+        """Yield response body in chunks to support large files."""
+        try:
+            while chunk := resp.read(CHUNK_SIZE):
+                yield chunk
+        finally:
+            resp.close()


### PR DESCRIPTION
## Summary

- Adds a new `--forward PATTERN=URL` CLI argument (repeatable) that forwards matching requests to an external server
- New `ForwardProxy` WSGI middleware with chunk-based streaming (memory-safe for large files)
- Forward rules are registered in the Dispatcher before the gunicorn proxy, so they take priority for matching patterns
- Non-matching requests and errors fall through to the local app — no regression

## Use case

During local development, files uploaded to production (Google Cloud Storage) aren't available in the local Datastore emulator. This option transparently proxies those requests to the production server:

```bash
app_server -A my-app \
    --forward '/file/.*=https://my-app.appspot.com' \
    deploy/
```

## Test plan

- [x] Tested with a real ViUR project (verwischte-tinte): `/file/download/...` returns `200 OK` with correct `content-type`
- [x] Non-forwarded routes (`/json/...`, static files) still work as before
- [x] Without `--forward`: behavior unchanged (no regression)
- [ ] Review: streaming works for large files (>4 GB) without memory issues