### PR TITLE
fix: Loosen `gunicorn` requirement to `>=23,<27`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.8
 install_requires =
     werkzeug~=3.1.2
     pyyaml~=6.0
-    gunicorn~=23.0.0
+    gunicorn>=23,<27
     fs~=2.4.16
     grpcio>=1.58.0
 


### PR DESCRIPTION
The previous `gunicorn~=23.0.0` only allowed 23.0.x, which conflicts with `viur-core` (`gunicorn>=23,<27`) and blocked resolution to current gunicorn releases (24/25/26). The only internal coupling, `patch_gunicorn()` in `utils.py`, still applies cleanly on gunicorn 26 (the patched line in `gunicorn/workers/base.py` is unchanged).

--- 
Similar to https://github.com/viur-framework/viur-core/pull/1716